### PR TITLE
Add quickstart to README and GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run tests
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -23,6 +23,23 @@ FSK currently is only supported on unix platforms,to install please refer to the
 
 * [FSK Wiki](https://github.com/RyanSowden/fsk/wiki)
 
+# Quickstart
+The wiki covers the full setup flow, but a minimal local run looks like:
+
+1. Install dependencies: `pip install -r requirements.txt`
+2. Configure environment variables in a `.env` file (see the wiki for required values).
+3. Run the bot: `python bot.py`
+
+If you hit database errors, double-check the wiki setup guide for required tables.
+
+# Testing
+Run the test suite locally with:
+
+`pytest`
+
+# Supported versions
+FSK is tested with Python 3.9+ on Unix-like platforms.
+
 # Contributing
 FSK is 100% open source and always looking at ways to become better, so if you have any ideas on ways to improve/add to the bot, create a pull request stating what you have changed/added.
 


### PR DESCRIPTION
### Motivation
- Provide a minimal local Quickstart so new users can run the bot without digging through the wiki. 
- Add a lightweight CI to automatically run the test suite on pushes and pull requests to catch regressions early.

### Description
- Updated `README.md` to include a `Quickstart` section with minimal run steps (`pip install -r requirements.txt`, create a `.env`, `python bot.py`).
- Added `Testing` and `Supported versions` notes to `README.md` indicating to run `pytest` and that the project targets Python 3.9+ on Unix-like platforms.
- Added `.github/workflows/ci.yml` to run a CI job on `push` and `pull_request` which sets up Python 3.9, installs dependencies with `pip install -r requirements.txt`, and runs `pytest`.

### Testing
- No automated tests were executed locally as this change is documentation and CI configuration only.
- CI workflow was added to run `pytest` on GitHub Actions for `push` and `pull_request` events.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69741676ed8483318108ab5dd3880c83)